### PR TITLE
feat(frontend): add reusable UI components

### DIFF
--- a/sliptail-frontend/package-lock.json
+++ b/sliptail-frontend/package-lock.json
@@ -16,7 +16,6 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@tailwindcss/postcss": "^4",
-        "@types/axios": "^0.9.36",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -1276,13 +1275,6 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
-    },
-    "node_modules/@types/axios": {
-      "version": "0.9.36",
-      "resolved": "https://registry.npmjs.org/@types/axios/-/axios-0.9.36.tgz",
-      "integrity": "sha512-NLOpedx9o+rxo/X5ChbdiX6mS1atE4WHmEEIcR9NLenRVa5HoVjAvjafwU3FPTqnZEstpoqCaW7fagqSoTDNeg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",

--- a/sliptail-frontend/package.json
+++ b/sliptail-frontend/package.json
@@ -17,7 +17,6 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
-    "@types/axios": "^0.9.36",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/sliptail-frontend/src/app/layout.tsx
+++ b/sliptail-frontend/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import { AuthProvider } from "@/components/auth/AuthProvider";
+import { Navbar, Footer } from "@/components/ui";
 
 export const metadata: Metadata = {
   title: "Sliptail",
@@ -10,8 +11,12 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body className="min-h-screen bg-neutral-50 text-neutral-900">
-        <AuthProvider>{children}</AuthProvider>
+      <body className="flex min-h-screen flex-col bg-neutral-50 text-neutral-900">
+        <AuthProvider>
+          <Navbar />
+          <main className="flex-1">{children}</main>
+          <Footer />
+        </AuthProvider>
       </body>
     </html>
   );

--- a/sliptail-frontend/src/app/page.tsx
+++ b/sliptail-frontend/src/app/page.tsx
@@ -1,15 +1,33 @@
+"use client";
+
+import { Button, Card, Input } from "@/components/ui";
+
 export default function Home() {
   return (
-    <main className="p-6 max-w-3xl mx-auto">
-      <h1 className="text-2xl font-bold mb-2">Welcome to Sliptail</h1>
-      <p className="text-neutral-600">
-        This is your Next.js frontend. Use the nav to log in and view the dashboard.
-      </p>
-      <div className="mt-6 space-x-3">
-        <a className="underline" href="/auth/login">Login</a>
-        <a className="underline" href="/auth/signup">Sign up</a>
-        <a className="underline" href="/dashboard">Dashboard</a>
-      </div>
+    <main className="mx-auto max-w-3xl p-6">
+      <Card title="Welcome to Sliptail">
+        <p className="text-neutral-600">
+          This is your Next.js frontend. Use the nav to log in and view the dashboard.
+        </p>
+        <div className="mt-6 space-y-4">
+          <Input placeholder="Try the input" />
+          <div className="space-x-3">
+            <Button onClick={() => (window.location.href = "/auth/login")}>Login</Button>
+            <Button
+              variant="secondary"
+              onClick={() => (window.location.href = "/auth/signup")}
+            >
+              Sign up
+            </Button>
+            <Button
+              variant="secondary"
+              onClick={() => (window.location.href = "/dashboard")}
+            >
+              Dashboard
+            </Button>
+          </div>
+        </div>
+      </Card>
     </main>
   );
 }

--- a/sliptail-frontend/src/components/ui/Button.tsx
+++ b/sliptail-frontend/src/components/ui/Button.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import React from "react";
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: "primary" | "secondary";
+}
+
+export function Button({ variant = "primary", className = "", ...props }: ButtonProps) {
+  const base = "px-4 py-2 rounded-md font-medium focus:outline-none";
+  const variants: Record<string, string> = {
+    primary: "bg-blue-600 text-white hover:bg-blue-500",
+    secondary: "bg-gray-200 text-gray-800 hover:bg-gray-300",
+  };
+
+  return (
+    <button
+      className={`${base} ${variants[variant]} ${className}`}
+      {...props}
+    />
+  );
+}
+

--- a/sliptail-frontend/src/components/ui/Card.tsx
+++ b/sliptail-frontend/src/components/ui/Card.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import React from "react";
+
+interface CardProps {
+  title?: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function Card({ title, children, className = "" }: CardProps) {
+  return (
+    <div className={`rounded-lg border bg-white shadow ${className}`}>
+      {title && <div className="border-b p-4 text-lg font-semibold">{title}</div>}
+      <div className="p-4">{children}</div>
+    </div>
+  );
+}
+

--- a/sliptail-frontend/src/components/ui/Footer.tsx
+++ b/sliptail-frontend/src/components/ui/Footer.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import React from "react";
+
+export function Footer({ className = "" }: { className?: string }) {
+  return (
+    <footer className={`bg-gray-100 text-gray-600 ${className}`}>
+      <div className="mx-auto max-w-7xl px-4 py-6 text-center text-sm">
+        &copy; {new Date().getFullYear()} Sliptail. All rights reserved.
+      </div>
+    </footer>
+  );
+}
+

--- a/sliptail-frontend/src/components/ui/Input.tsx
+++ b/sliptail-frontend/src/components/ui/Input.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import React from "react";
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+export function Input({ className = "", ...props }: InputProps) {
+  const base =
+    "w-full rounded-md border border-gray-300 px-3 py-2 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500";
+  return <input className={`${base} ${className}`} {...props} />;
+}
+

--- a/sliptail-frontend/src/components/ui/Navbar.tsx
+++ b/sliptail-frontend/src/components/ui/Navbar.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import Link from "next/link";
+import React from "react";
+
+interface NavbarLink {
+  href: string;
+  label: string;
+}
+
+interface NavbarProps {
+  links?: NavbarLink[];
+}
+
+export function Navbar({ links = [] }: NavbarProps) {
+  return (
+    <nav className="bg-gray-800 text-white">
+      <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-3">
+        <Link href="/" className="text-lg font-bold">
+          Sliptail
+        </Link>
+        <div className="space-x-4">
+          {links.map((link) => (
+            <Link key={link.href} href={link.href} className="hover:underline">
+              {link.label}
+            </Link>
+          ))}
+        </div>
+      </div>
+    </nav>
+  );
+}
+

--- a/sliptail-frontend/src/components/ui/index.ts
+++ b/sliptail-frontend/src/components/ui/index.ts
@@ -1,0 +1,5 @@
+export { Button } from "./Button";
+export { Input } from "./Input";
+export { Card } from "./Card";
+export { Navbar } from "./Navbar";
+export { Footer } from "./Footer";

--- a/sliptail-frontend/src/lib/api.ts
+++ b/sliptail-frontend/src/lib/api.ts
@@ -1,3 +1,5 @@
+import axios, { type AxiosError } from "axios";
+
 export const API_BASE =
   process.env.NEXT_PUBLIC_API_URL?.replace(/\/$/, "") || "http://localhost:5000";
 
@@ -51,20 +53,13 @@ export async function fetchApi<T>(
 // ------------------------------------------------------------------
 // Axios instance (Axios v1+ compatible typings)
 // ------------------------------------------------------------------
-import axios from "axios";
-import type  { AxiosRequestConfig, AxiosError } from "axios";
-
-// If your backend mounts all routes under /api, include it here:
-const AXIOS_BASE =
-  process.env.NEXT_PUBLIC_API_URL?.replace(/\/$/, "") || "http://localhost:5000";
-
 export const api = axios.create({
-  baseURL: AXIOS_BASE,
+  baseURL: API_BASE,
   withCredentials: false, // set true if you later use httpOnly cookies/sessions
 });
 
 // Attach Authorization header from localStorage token (client only)
-api.interceptors.request.use((config: AxiosRequestConfig) => {
+api.interceptors.request.use((config) => {
   if (typeof window !== "undefined") {
     const token = localStorage.getItem("token");
     if (token) {


### PR DESCRIPTION
## Summary
- add reusable Button, Input, Card, Navbar, and Footer components
- integrate Navbar and Footer into the root layout
- showcase components on the home page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b66718cbcc83258260b951e1268832