### PR TITLE
feat: add reusable UI components

### DIFF
--- a/sliptail-frontend/src/components/ui/Button.tsx
+++ b/sliptail-frontend/src/components/ui/Button.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  className?: string;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className = "", ...props }, ref) => (
+    <button
+      ref={ref}
+      className={`px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 ${className}`}
+      {...props}
+    />
+  )
+);
+
+Button.displayName = "Button";
+
+export default Button;

--- a/sliptail-frontend/src/components/ui/Card.tsx
+++ b/sliptail-frontend/src/components/ui/Card.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+export interface CardProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export default function Card({ children, className = "" }: CardProps) {
+  return (
+    <div className={`rounded border bg-white p-4 shadow-sm ${className}`}>
+      {children}
+    </div>
+  );
+}

--- a/sliptail-frontend/src/components/ui/Footer.tsx
+++ b/sliptail-frontend/src/components/ui/Footer.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+export interface FooterProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export default function Footer({ children, className = "" }: FooterProps) {
+  return (
+    <footer className={`bg-gray-100 p-4 text-center text-sm text-gray-500 ${className}`}>
+      {children}
+    </footer>
+  );
+}

--- a/sliptail-frontend/src/components/ui/Input.tsx
+++ b/sliptail-frontend/src/components/ui/Input.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  className?: string;
+}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className = "", ...props }, ref) => (
+    <input
+      ref={ref}
+      className={`border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 ${className}`}
+      {...props}
+    />
+  )
+);
+
+Input.displayName = "Input";
+
+export default Input;

--- a/sliptail-frontend/src/components/ui/Navbar.tsx
+++ b/sliptail-frontend/src/components/ui/Navbar.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+export interface NavbarProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export default function Navbar({ children, className = "" }: NavbarProps) {
+  return (
+    <nav className={`flex items-center justify-between bg-gray-800 p-4 text-white ${className}`}>
+      {children}
+    </nav>
+  );
+}

--- a/sliptail-frontend/src/components/ui/index.ts
+++ b/sliptail-frontend/src/components/ui/index.ts
@@ -1,0 +1,5 @@
+export { default as Button } from "./Button";
+export { default as Input } from "./Input";
+export { default as Card } from "./Card";
+export { default as Navbar } from "./Navbar";
+export { default as Footer } from "./Footer";


### PR DESCRIPTION
## Summary
- add reusable Button, Input, Card, Navbar, and Footer components
- export new components from a central ui index

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6844ea0d88325a3d9b316c9a1fa90