### PR TITLE
feat: add creator-centric home page and card

### DIFF
--- a/sliptail-frontend/src/app/page.tsx
+++ b/sliptail-frontend/src/app/page.tsx
@@ -1,102 +1,49 @@
-import Link from "next/link";
+import CreatorCard from "@/components/CreatorCard";
 
+const featured = [
+  {
+    id: "1",
+    displayName: "Alice",
+    avatar: "https://images.unsplash.com/photo-1544723795-3fb6469f5b39?w=100&h=100&fit=crop",
+    bio: "Photographer & traveler",
+    rating: 4.8,
+    photos: [
+      "https://images.unsplash.com/photo-1529626455594-4ff0802cfb7e?w=200&h=200&fit=crop",
+      "https://images.unsplash.com/photo-1503023345310-bd7c1de61c7d?w=200&h=200&fit=crop",
+      "https://images.unsplash.com/photo-1487412912498-0447578fcca8?w=200&h=200&fit=crop",
+      "https://images.unsplash.com/photo-1503264116251-35a269479413?w=200&h=200&fit=crop",
+    ],
+  },
+];
 
-function Badge({ children }: { children: React.ReactNode }) {
-return <span className="inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium">{children}</span>;
-}
+const categories = ["art", "photography", "music", "fashion"];
 
+export default function Home() {
+  return (
+    <main className="mx-auto max-w-6xl px-6 py-8">
+      <section className="mb-12">
+        <h1 className="mb-4 text-3xl font-bold">Featured Sellers</h1>
+        <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-3">
+          {featured.map((c) => (
+            <CreatorCard key={c.id} creator={c} />
+          ))}
+        </div>
+      </section>
 
-function Button(
-{ children, href, variant = "primary" }:
-{ children: React.ReactNode; href: string; variant?: "primary" | "ghost" }
-) {
-const base = "inline-flex items-center justify-center rounded-2xl px-4 py-2 text-sm font-semibold transition active:translate-y-px";
-const styles = variant === "primary" ? "bg-black text-white hover:bg-black/90 shadow" : "bg-white text-black hover:bg-neutral-100 border";
-return (
-<Link href={href} className={`${base} ${styles}`}>
-{children}
-</Link>
-);
-}
-
-
-export default function HomePage() {
-return (
-<main>
-{/* Hero */}
-<section className="relative overflow-hidden border-b bg-gradient-to-b from-white to-neutral-50">
-<div className="mx-auto grid max-w-6xl grid-cols-1 items-center gap-10 px-4 py-16 md:grid-cols-2">
-<div>
-<h1 className="text-4xl font-extrabold tracking-tight md:text-5xl">
-Build your audience. <span className="underline decoration-black/20">Own your income</span>.
-</h1>
-<p className="mt-4 text-neutral-700 md:text-lg">
-Sell memberships, digital downloads, and custom requests—all in one place.
-</p>
-<div className="mt-6 flex gap-3">
-<Button href="/auth/signup">Start for free</Button>
-<Button href="/creators" variant="ghost">Explore creators</Button>
-</div>
-<div className="mt-6 flex items-center gap-3 text-xs text-neutral-600">
-<Badge>No monthly fees</Badge>
-<Badge>Payouts via Stripe</Badge>
-<Badge>Video-ready uploads</Badge>
-</div>
-</div>
-<div className="aspect-video w-full overflow-hidden rounded-2xl border shadow">
-<img className="h-full w-full object-cover" alt="Creator montage" src="https://images.unsplash.com/photo-1518837695005-2083093ee35b?q=80&w=1600&auto=format&fit=crop" />
-</div>
-</div>
-</section>
-
-
-{/* Quick links row */}
-<section className="mx-auto max-w-6xl px-4 py-10">
-<div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
-<Link href="/creators" className="rounded-2xl border p-4 hover:bg-neutral-50">
-<div className="text-sm font-semibold">Browse creators →</div>
-<div className="mt-1 text-sm text-neutral-600">Find someone to support</div>
-</Link>
-<Link href="/products" className="rounded-2xl border p-4 hover:bg-neutral-50">
-<div className="text-sm font-semibold">Explore products →</div>
-<div className="mt-1 text-sm text-neutral-600">Downloads, memberships, requests</div>
-</Link>
-<Link href="/auth/login" className="rounded-2xl border p-4 hover:bg-neutral-50">
-<div className="text-sm font-semibold">Sign in →</div>
-<div className="mt-1 text-sm text-neutral-600">Access your account</div>
-</Link>
-<Link href="/dashboard" className="rounded-2xl border p-4 hover:bg-neutral-50">
-<div className="text-sm font-semibold">Creator dashboard →</div>
-<div className="mt-1 text-sm text-neutral-600">Manage products & sales</div>
-</Link>
-</div>
-</section>
-
-
-{/* How it works */}
-<section id="how" className="mt-4 bg-neutral-50/60 py-16">
-<div className="mx-auto max-w-6xl px-4">
-<h3 className="text-xl font-bold">How it works</h3>
-<ol className="mt-4 grid list-decimal gap-3 pl-5 text-sm text-neutral-700 md:grid-cols-2">
-<li>Creators connect Stripe and publish products (downloads, memberships, requests).</li>
-<li>Fans browse, purchase, and request via secure checkout.</li>
-<li>Deliver digital files instantly; manage memberships & perks.</li>
-<li>Creators track sales and payouts in their dashboard.</li>
-</ol>
-</div>
-</section>
-
-
-{/* Footer */}
-<footer className="mt-20 border-t">
-<div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-4 px-4 py-10 md:flex-row">
-<div className="flex items-center gap-3">
-<span className="inline-block h-7 w-7 rounded-2xl bg-black" />
-<span className="text-sm font-semibold">Sliptail</span>
-</div>
-<p className="text-xs text-neutral-600">© {new Date().getFullYear()} Sliptail. All rights reserved.</p>
-</div>
-</footer>
-</main>
-);
+      <section>
+        <h2 className="mb-4 text-2xl font-semibold">Explore by category</h2>
+        <div className="flex flex-wrap gap-3">
+          {categories.map((cat) => (
+            <a
+              key={cat}
+              href={`/creators?category=${cat}`}
+              className="rounded bg-neutral-200 px-4 py-2 hover:bg-neutral-300"
+            >
+              {cat}
+            </a>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
 }

--- a/sliptail-frontend/src/components/CreatorCard.tsx
+++ b/sliptail-frontend/src/components/CreatorCard.tsx
@@ -1,0 +1,62 @@
+import Image from "next/image";
+import Link from "next/link";
+
+interface Creator {
+  id: string;
+  displayName: string;
+  avatar: string;
+  bio: string;
+  rating: number;
+  photos: string[];
+}
+
+export default function CreatorCard({ creator }: { creator: Creator }) {
+  return (
+    <div className="group relative h-80 w-64 [perspective:1000px]">
+      <div className="relative h-full w-full transition-transform duration-500 [transform-style:preserve-3d] group-hover:[transform:rotateY(180deg)]">
+        {/* front */}
+        <div className="absolute inset-0 flex flex-col items-center rounded border bg-white p-4 [backface-visibility:hidden]">
+          <Image
+            src={creator.avatar}
+            alt={creator.displayName}
+            width={80}
+            height={80}
+            className="mb-2 rounded-full"
+          />
+          <h3 className="font-semibold">{creator.displayName}</h3>
+          <p className="text-center text-sm text-gray-600">{creator.bio}</p>
+          <div className="mt-2 flex items-center">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              className="h-4 w-4 text-yellow-500"
+            >
+              <path d="M12 .587l3.668 7.431 8.2 1.193-5.934 5.787 1.402 8.168L12 18.896l-7.336 3.87 1.402-8.168L.132 9.211l8.2-1.193z" />
+            </svg>
+            <span className="ml-1 text-sm">{creator.rating.toFixed(1)}</span>
+          </div>
+        </div>
+        {/* back */}
+        <div className="absolute inset-0 grid grid-cols-2 gap-1 rounded border bg-white p-2 [transform:rotateY(180deg)] [backface-visibility:hidden]">
+          {creator.photos.slice(0, 4).map((src, i) => (
+            <Image
+              key={i}
+              src={src}
+              alt=""
+              width={120}
+              height={120}
+              className="h-full w-full object-cover"
+            />
+          ))}
+          <Link
+            href={`/creators/${creator.id}`}
+            className="col-span-2 mt-1 rounded bg-blue-600 py-1 text-center text-white"
+          >
+            View Profile
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `CreatorCard` component showing creator info with flip animation
- rewrite home page to highlight featured sellers and categories without product links

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any in src/components/auth/AuthProvider.tsx)


------
https://chatgpt.com/codex/tasks/task_e_68b73125a2e883258db7e5f362757a76