### PR TITLE
feat: redesign homepage with creator sections

### DIFF
--- a/sliptail-frontend/public/sliptail-logo.svg
+++ b/sliptail-frontend/public/sliptail-logo.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 80" fill="none">
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#22c55e" />
+      <stop offset="100%" stop-color="#16a34a" />
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="80" height="80" rx="10" fill="url(#grad)" />
+  <text x="40" y="52" text-anchor="middle" font-size="48" font-weight="700" fill="#ffffff">S</text>
+  <text x="95" y="53" font-size="36" font-weight="700" fill="#16a34a">SLIPTAIL</text>
+</svg>

--- a/sliptail-frontend/src/app/globals.css
+++ b/sliptail-frontend/src/app/globals.css
@@ -24,3 +24,18 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+@keyframes fade-in-up {
+  0% {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-fade-in-up {
+  animation: fade-in-up 0.8s ease-out both;
+}

--- a/sliptail-frontend/src/app/page.tsx
+++ b/sliptail-frontend/src/app/page.tsx
@@ -1,3 +1,5 @@
+import Image from "next/image";
+import Link from "next/link";
 import CreatorCard from "@/components/CreatorCard";
 
 const featured = [
@@ -20,34 +22,96 @@ const categories = ["art", "photography", "music", "fashion"];
 
 export default function Home() {
   return (
-    <main className="mx-auto max-w-6xl px-6 py-8">
-      <section className="mb-12 text-center">
-        <h1 className="text-4xl font-bold">Support and Connect with your favorite creators</h1>
-      </section>
-
-      <section className="mb-12">
-        <h2 className="mb-4 text-3xl font-bold">Featured Creators</h2>
-        <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-3">
-          {featured.map((c) => (
-            <CreatorCard key={c.id} creator={c} />
-          ))}
+    <div className="font-sans">
+      {/* Hero Section */}
+      <section className="relative overflow-hidden bg-gradient-to-r from-green-400 to-green-600 text-white">
+        <div className="mx-auto max-w-6xl px-6 py-24 text-center">
+          <div className="mx-auto mb-6 w-40 animate-fade-in-up">
+            <Image src="/sliptail-logo.svg" alt="Sliptail" width={160} height={50} />
+          </div>
+          <h1 className="mb-4 text-5xl font-bold animate-fade-in-up [animation-delay:200ms]">Support and Create</h1>
+          <p className="mx-auto mb-8 max-w-2xl text-lg animate-fade-in-up [animation-delay:400ms]">
+            Sliptail helps creators provide memberships, digital downloads, and custom requests — all in one place.
+          </p>
+          <div className="flex flex-col items-center justify-center gap-4 sm:flex-row">
+            <Link
+              href="/auth/signup"
+              className="rounded-md bg-white px-8 py-3 font-semibold text-green-700 shadow transition hover:scale-105"
+            >
+              For Creators: Start Selling
+            </Link>
+            <Link
+              href="/creators"
+              className="rounded-md border border-white px-8 py-3 font-semibold text-white transition hover:scale-105 hover:bg-white/20"
+            >
+              For Fans: Explore Creators
+            </Link>
+          </div>
         </div>
       </section>
 
-      <section>
-        <h2 className="mb-4 text-2xl font-semibold">Explore by category</h2>
+      {/* For Creators & Fans Blocks */}
+      <section className="mx-auto max-w-6xl px-6 py-16">
+        <div className="grid gap-8 md:grid-cols-2">
+          <div className="rounded-2xl bg-gray-50 p-8 shadow transition hover:shadow-lg">
+            <h2 className="mb-4 text-3xl font-bold text-green-600">Built for creators like you</h2>
+            <p className="text-gray-700">
+              Upload videos, e-books, or any digital content. Offer memberships with exclusive perks. Accept custom requests.
+              Connect Stripe and start earning in minutes.
+            </p>
+          </div>
+          <div className="rounded-2xl bg-gray-50 p-8 shadow transition hover:shadow-lg">
+            <h2 className="mb-4 text-3xl font-bold text-green-600">Support your favorites</h2>
+            <p className="text-gray-700">
+              Subscribe to your favorite creators, download their work, or request something personal. It’s never been easier to support
+              creativity.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Featured Creators */}
+      <section className="bg-gray-50 py-16">
+        <div className="mx-auto max-w-6xl px-6">
+          <h2 className="mb-8 text-center text-3xl font-bold">Featured Creators</h2>
+          <div className="grid justify-items-center gap-6 sm:grid-cols-2 md:grid-cols-3">
+            {featured.map((c) => (
+              <CreatorCard key={c.id} creator={c} />
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Explore Categories */}
+      <section className="mx-auto max-w-6xl px-6 py-16">
+        <h2 className="mb-4 text-2xl font-bold">Explore by category</h2>
         <div className="flex flex-wrap gap-3">
           {categories.map((cat) => (
             <a
               key={cat}
               href={`/creators?category=${cat}`}
-              className="rounded bg-neutral-200 px-4 py-2 hover:bg-neutral-300"
+              className="rounded-full border border-green-500 px-5 py-2 capitalize text-green-700 transition hover:bg-green-50"
             >
               {cat}
             </a>
           ))}
         </div>
       </section>
-    </main>
+
+      {/* CTA */}
+      <section className="bg-gradient-to-r from-green-500 to-green-700 py-20 text-center text-white">
+        <h2 className="mb-4 text-4xl font-bold">Join Sliptail today</h2>
+        <p className="mx-auto mb-8 max-w-xl text-lg">
+          Whether you’re a creator or a fan, Sliptail makes connecting simple, safe, and fun.
+        </p>
+        <Link
+          href="/auth/signup"
+          className="rounded-md bg-white px-8 py-3 font-semibold text-green-700 shadow transition hover:scale-105"
+        >
+          Get Started
+        </Link>
+      </section>
+    </div>
   );
 }
+

--- a/sliptail-frontend/src/components/Navbar.tsx
+++ b/sliptail-frontend/src/components/Navbar.tsx
@@ -1,4 +1,5 @@
 "use client";
+import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
@@ -10,31 +11,40 @@ const links = [
 
 
 export default function Navbar() {
-const pathname = usePathname();
-const isActive = (href: string) => (pathname === href ? "text-black" : "text-neutral-700");
+  const pathname = usePathname();
+  const isActive = (href: string) => (pathname === href ? "text-black" : "text-neutral-700");
 
-
-return (
-<header className="sticky top-0 z-40 w-full border-b bg-white/70 backdrop-blur">
-<div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3">
-<div className="flex items-center gap-3">
-<Link href="/" className="flex items-center gap-3">
-<span className="inline-block h-8 w-8 rounded-2xl bg-black" />
-<span className="text-lg font-bold tracking-tight">Sliptail</span>
-</Link>
-</div>
-<nav className="hidden gap-6 md:flex">
-{links.map((l) => (
-<Link key={l.href} href={l.href} className={`text-sm hover:text-black ${isActive(l.href)}`}>
-{l.label}
-</Link>
-))}
-</nav>
-<div className="flex items-center gap-2">
-<Link href="/auth/login" className="rounded-2xl border px-4 py-2 text-sm font-semibold hover:bg-neutral-100">Sign in</Link>
-<Link href="/auth/signup" className="rounded-2xl bg-black px-4 py-2 text-sm font-semibold text-white hover:bg-black/90">Become a creator</Link>
-</div>
-</div>
-</header>
-);
+  return (
+    <header className="sticky top-0 z-40 w-full border-b bg-white/70 backdrop-blur">
+      <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3">
+        <div className="flex items-center gap-3">
+          <Link href="/" className="flex items-center gap-3">
+            <Image src="/sliptail-logo.svg" alt="Sliptail" width={130} height={40} />
+          </Link>
+        </div>
+        <nav className="hidden gap-6 md:flex">
+          {links.map((l) => (
+            <Link key={l.href} href={l.href} className={`text-sm hover:text-black ${isActive(l.href)}`}>
+              {l.label}
+            </Link>
+          ))}
+        </nav>
+        <div className="flex items-center gap-2">
+          <Link
+            href="/auth/login"
+            className="rounded-2xl border px-4 py-2 text-sm font-semibold hover:bg-neutral-100"
+          >
+            Sign in
+          </Link>
+          <Link
+            href="/auth/signup"
+            className="rounded-2xl bg-black px-4 py-2 text-sm font-semibold text-white hover:bg-black/90"
+          >
+            Become a creator
+          </Link>
+        </div>
+      </div>
+    </header>
+  );
 }
+


### PR DESCRIPTION
## Summary
- redesign homepage with hero, creator/fan blocks, featured creators, categories and CTA
- add sliptail logo and navbar update
- introduce simple fade-in animation styling

## Testing
- `npm run lint` *(fails: Unexpected any in AuthProvider.tsx)*
- `npm run build` *(fails: Property 'response' does not exist on type '{}' in AuthProvider.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b75dd163f883259e780644fbf39a37